### PR TITLE
Moment based policy

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,7 @@
 *.pyc
 # Byte-compiled / optimized / DLL files
 __pycache__/
-src/crazyflie_rl/src/log/*.csv
+src/ros_nodes/data_logging_pkg/log/*.csv
 *.py[cod]
 *$py.class
 .vscode

--- a/src/crazyflie_gazebo/src/controller.cpp
+++ b/src/crazyflie_gazebo/src/controller.cpp
@@ -174,7 +174,7 @@ void Controller::RLCmd_Callback(const crazyflie_rl::RLCmd::ConstPtr &msg){
 
         case 7: // Execute Moment Based Flip
 
-            _M_d = cmd_vals;
+            _M_d = cmd_vals*1e-3;
             _Moment_flag = true;
 
             break;
@@ -288,7 +288,7 @@ void Controller::controlThread()
     double d = 0.040; // Distance from COM to prop [m]
     double d_p = d*sin(M_PI/4);
 
-    double kf = 2.21e-8; // Thrust constant [N/(rad/s)^2]
+    double kf = 2.2e-8; // Thrust constant [N/(rad/s)^2]
     double c_Tf = 0.00612; // Moment Constant [Nm/N]
 
     Matrix3d J; // Rotational Inertia of CF
@@ -438,7 +438,7 @@ void Controller::controlThread()
         
 
 
-        if (t_step%1 == 0){ // General Debugging output
+        if (t_step%100 == 0){ // General Debugging output
         cout << setprecision(4) <<
         "t: " << t << "\tCmd: " << ctrl_cmd.transpose() << endl << 
         endl <<

--- a/src/crazyflie_gazebo/src/controller.h
+++ b/src/crazyflie_gazebo/src/controller.h
@@ -98,6 +98,7 @@ class Controller
         Eigen::Vector3d _a_d;       // Acceleration-desired [m/s]
         Eigen::Vector3d _b1_d;      // Desired body-fixed x-axis in terms of global axes
         Eigen::Vector3d _omega_d;   // Omega-desired [rad/s]
+        Eigen::Vector3d _M_d;       // Moment-desired [N*m]
 
         Eigen::Vector3d _kp_x; // Pos. Gain
         Eigen::Vector3d _kd_x; // Pos. derivative Gain
@@ -120,6 +121,7 @@ class Controller
 
         bool _motorstop_flag = false;
         bool _flip_flag = false;
+        bool _Moment_flag = false;
 
 
 

--- a/src/crazyflie_rl/msg/RLData.msg
+++ b/src/crazyflie_rl/msg/RLData.msg
@@ -24,4 +24,5 @@ float32[] policy
 float32 reward
 
 float32[] vel_d
-float32[] omega_d
+float32[] M_d
+

--- a/src/crazyflie_rl/src/CF_training.py
+++ b/src/crazyflie_rl/src/CF_training.py
@@ -71,7 +71,7 @@ def runTrial(vx_d,vz_d):
         print("theta_rl = ")
         print(theta_rl[0,:], "--> RREV")
         print(theta_rl[1,:], "--> Gain_RREV")
-        print(theta_rl[1,:], "--> Gain_OF_y")
+        print(theta_rl[2,:], "--> Gain_OF_y")
 
 
 
@@ -85,7 +85,7 @@ def runTrial(vx_d,vz_d):
 
 
             ## RESET TO INITIAL STATE
-            env.step('home',ctrl_flag=1) # Reset control vals and functionality to default vals
+            env.step('home') # Reset control vals and functionality to default vals
             time.sleep(1.0) # Time for CF to settle
             
 
@@ -160,19 +160,19 @@ def runTrial(vx_d,vz_d):
             
                     env.step('sticky',ctrl_flag=1)
 
-                    omega_yd = (G1*RREV - G2*abs(OF_y))*np.sign(OF_y)
-                    omega_xd = 0.0
-                    omega_zd = 0.0
+                    Mx_d = 0.0
+                    My_d = (G1*(RREV*1e-1) - G2*abs(OF_y*1e-1))*np.sign(OF_y)
+                    Mz_d = 0.0
 
-                    env.omega_d = [omega_xd,omega_yd,omega_zd]
+                    env.M_d = [Mx_d,My_d,Mz_d] # [N*mm]
 
                     print('----- pitch starts -----')
                     print('vx=%.3f, vy=%.3f, vz=%.3f' %(vx,vy,vz))
-                    print('RREV=%.3f, OF_y=%.3f, OF_x=%.3f, Omega_yd=%.3f' %(RREV, OF_y, OF_x, omega_yd) )   
+                    print('RREV=%.3f, OF_y=%.3f, OF_x=%.3f, Omega_yd=%.3f' %(RREV, OF_y, OF_x, My_d) )   
                     print("Pitch Time: %.3f" %start_time_pitch)
 
                     ## Start rotation and mark rotation as triggered
-                    env.step('omega',env.omega_d,ctrl_flag=1) # Set desired ang. vel 
+                    env.step('moment',env.M_d,ctrl_flag=1) # Set desired ang. vel 
                    
                     env.flip_flag = True
 
@@ -295,7 +295,7 @@ if __name__ == '__main__':
     alpha_sigma = np.array([[0.05]])
 
     ## GAUSSIAN PARAMETERS
-    mu = np.array([[5.0],[6.0],[6.0]])# Initial estimates of mu: 
+    mu = np.array([[5.0],[10],[6.0]])# Initial estimates of mu: 
     sigma = np.array([[1.5],[1.5],[1.5]]) # Initial estimates of sigma: 
 
 
@@ -308,8 +308,8 @@ if __name__ == '__main__':
 
     
     ## INITIAL CONDITIONS
-    vx_d = 1.0
-    vz_d = 3.0
+    vx_d = 1.5
+    vz_d = 3.5
     trial_num = 1
     env.agent = "EM_PEPG"
     

--- a/src/crazyflie_rl/src/RL_Policy_Playground.py
+++ b/src/crazyflie_rl/src/RL_Policy_Playground.py
@@ -1,15 +1,13 @@
 #!/usr/bin/env python3
 
 import numpy as np
-import time,os,getpass
+import time,os
 from scipy.spatial.transform import Rotation
-import threading
+
 
 
 from crazyflie_env import CrazyflieEnv
-from rl_syspepg import rlsysPEPGAgent_reactive,rlsysPEPGAgent_adaptive
-from rl_EM import rlEM_PEPGAgent,rlEM_AdaptiveAgent
-from rl_cma import CMA_basic,CMA,CMA_sym
+from rl_syspepg import rlsysPEPGAgent_reactive
 
 os.system("clear")
 np.set_printoptions(precision=2, suppress=True)
@@ -180,19 +178,19 @@ def runTrial():
             
                     env.step('sticky',ctrl_flag=1)
 
-                    omega_yd = (G1*RREV - G2*abs(OF_y))*np.sign(OF_y)
-                    omega_xd = 0.0
-                    omega_zd = 0.0
+                    M_xd = 0.0
+                    M_yd = (G1*RREV - G2*abs(OF_y))*np.sign(OF_y)
+                    M_zd = 0.0
 
-                    env.omega_d = [omega_xd,omega_yd,omega_zd]
+                    env.M_d = [M_xd,M_yd,M_zd]
 
                     print('----- pitch starts -----')
                     print('vx=%.3f, vy=%.3f, vz=%.3f' %(vx,vy,vz))
-                    print('RREV=%.3f, OF_y=%.3f, OF_x=%.3f, Omega_yd=%.3f' %(RREV, OF_y, OF_x, omega_yd) )   
+                    print('RREV=%.3f, OF_y=%.3f, OF_x=%.3f, M_yd=%.3f' %(RREV, OF_y, OF_x, M_yd) )   
                     print("Pitch Time: %.3f" %start_time_pitch)
 
                     ## Start rotation and mark rotation as triggered
-                    env.step('omega',env.omega_d,ctrl_flag=1) # Set desired ang. vel 
+                    env.step('moment',env.M_d,ctrl_flag=1) # Set desired ang. vel 
                     env.flip_flag = True
 
                 # ============================
@@ -326,20 +324,14 @@ if __name__ == '__main__':
     while True:
         start_time = time.strftime('_%Y-%m-%d_%H:%M:%S', time.localtime(time.time()))
         env.trial_name = f"RL_Policy_Playground-{start_time}"
-        # try:
-            ## SEND MSG WHICH INCLUDES VARIABLE TO START NEW CSV
+
+        ## SEND MSG WHICH INCLUDES VARIABLE TO START NEW CSV
         env.createCSV_flag = True
         env.RL_Publish()
 
         ## RUN TRIAL AND RESTART GAZEBO FOR NEXT TRIAL RUN (NOT NECESSARY BUT MIGHT BE A GOOD IDEA?)
         runTrial()
-    
-        # except: ## IF SIM EXCEPTION RAISED THEN CONTINUE BACK TO TRY BLOCK UNTIL SUCCESSFUL COMPLETION
-        #     continue
 
-
-        # break ## BREAK FROM LOOP
-    
 
 
 

--- a/src/crazyflie_rl/src/crazyflie_env.py
+++ b/src/crazyflie_rl/src/crazyflie_env.py
@@ -72,6 +72,7 @@ class CrazyflieEnv:
 
         self.omega_d = [0,0,0]
         self.vel_d = [0,0,0]
+        self.M_d = [0,0,0]
 
         
         
@@ -128,7 +129,7 @@ class CrazyflieEnv:
         msg.reward = self.reward
 
         msg.vel_d = self.vel_d
-        msg.omega_d = self.omega_d
+        msg.M_d = self.M_d
 
         self.RL_Publisher.publish(msg)
      
@@ -287,7 +288,7 @@ class CrazyflieEnv:
                     'omega':4,
                     'stop':5,
                     'gains':6,
-                    'moments':7,
+                    'moment':7,
                     'sticky':11}
         
 
@@ -299,7 +300,7 @@ class CrazyflieEnv:
         
         self.Cmd_Publisher.publish(cmd_msg) # For some reason it doesn't always publish
         self.Cmd_Publisher.publish(cmd_msg) # So I'm sending it twice 
-        time.sleep(0.01)
+        time.sleep(0.01) # And a sleep for good measure, look back at removing this in the future 
         
 
 
@@ -313,7 +314,7 @@ class CrazyflieEnv:
             if action=='home' or action == 'stop': # Execute home or stop action
                 ctrl_vals = [0,0,0]
                 ctrl_flag = 1
-                self.stepPub(action,ctrl_vals,ctrl_flag)
+                self.step(action,ctrl_vals,ctrl_flag)
 
             elif action=='gains': # Execture Gain changer
                 
@@ -322,7 +323,7 @@ class CrazyflieEnv:
                 ctrl_vals = vals[0:3]
                 ctrl_flag = vals[3]
 
-                self.stepPub(action,ctrl_vals,ctrl_flag)
+                self.step(action,ctrl_vals,ctrl_flag)
                 
             elif action == 'omega': # Execture Angular rate action
 
@@ -330,14 +331,14 @@ class CrazyflieEnv:
                 ctrl_vals = [float(i) for i in ctrl_vals.split(',')]
                 ctrl_flag = 1.0
 
-                self.stepPub('omega',ctrl_vals,ctrl_flag)
+                self.step('omega',ctrl_vals,ctrl_flag)
 
 
             else:
                 ctrl_vals = input("\nControl Vals (x,y,z): ")
                 ctrl_vals = [float(i) for i in ctrl_vals.split(',')]
                 ctrl_flag = float(input("\nController On/Off (1,0): "))
-                self.stepPub(action,ctrl_vals,ctrl_flag)
+                self.step(action,ctrl_vals,ctrl_flag)
 
    
 

--- a/src/ros_nodes/dashboard_gui_pkg/src/dashboard_gui.py
+++ b/src/ros_nodes/dashboard_gui_pkg/src/dashboard_gui.py
@@ -106,10 +106,10 @@ def runGraph():
     line_wy, = ax1_omega.plot(buffer, wy_arr,'g-',label='$\omega_y$')
     line_wz, = ax1_omega.plot(buffer, wz_arr,'r-',label='$\omega_z$')
 
-    line_ms1, = ax1_ms.plot(buffer, ms1_arr,color = 'steelblue',linewidth = 1,label="MS: 1")
-    line_ms2, = ax1_ms.plot(buffer, ms2_arr,'b-',linewidth = 1,label="MS: 2")
-    line_ms3, = ax1_ms.plot(buffer, ms3_arr,'g-',linewidth = 1,label="MS: 3")
-    line_ms4, = ax1_ms.plot(buffer, ms4_arr,'r-',linewidth = 1,label="MS: 4")
+    line_ms1, = ax1_ms.plot(buffer, ms1_arr,color = 'steelblue',linewidth = 1.5,label="MS: 1")
+    line_ms2, = ax1_ms.plot(buffer, ms2_arr,'b-',linewidth = 1.5,label="MS: 2")
+    line_ms3, = ax1_ms.plot(buffer, ms3_arr,'g-',linewidth = 1.5,label="MS: 3")
+    line_ms4, = ax1_ms.plot(buffer, ms4_arr,'r-',linewidth = 1.5,label="MS: 4")
 
 
     ## DEFINE AXES LEGENDS
@@ -212,19 +212,20 @@ def runGraph():
         line_wz.set_ydata(wz_arr)
 
         ## MOTORSPEED LINES
-        ms1_arr.append(ms1)
+        lineoffset = 25
+        ms1_arr.append(ms1+lineoffset) # Added offsets so indiv. motorspeeds are visible on plot
         ms1_arr = ms1_arr[-buf_len:]
         line_ms1.set_ydata(ms1_arr)
 
-        ms2_arr.append(ms2)
+        ms2_arr.append(ms2-lineoffset)
         ms2_arr = ms2_arr[-buf_len:]
         line_ms2.set_ydata(ms2_arr)
 
-        ms3_arr.append(ms3)
+        ms3_arr.append(ms3+lineoffset)
         ms3_arr = ms3_arr[-buf_len:]
         line_ms3.set_ydata(ms3_arr)
 
-        ms4_arr.append(ms4)
+        ms4_arr.append(ms4-lineoffset)
         ms4_arr = ms4_arr[-buf_len:]
         line_ms4.set_ydata(ms4_arr)
 

--- a/src/ros_nodes/dashboard_gui_pkg/src/dashboard_node.py
+++ b/src/ros_nodes/dashboard_gui_pkg/src/dashboard_node.py
@@ -41,6 +41,10 @@ class DashboardNode:
         self.reward = reward_msg.reward
         self.n_rollouts = reward_msg.n_rollouts
 
+    # ============================
+    ##   Controller Subscriber
+    # ============================
+
     def ctrlCallback(self,msg):
         self.motorspeeds = msg.motorspeeds
 

--- a/src/ros_nodes/data_logging_pkg/src/dataLogging_node.py
+++ b/src/ros_nodes/data_logging_pkg/src/dataLogging_node.py
@@ -86,7 +86,7 @@ class DataLoggingNode:
         self.sigma = np.asarray(rl_msg.sigma)
         self.policy = np.asarray(rl_msg.policy)
         self.vel_d = np.asarray(rl_msg.vel_d)
-        self.omega_d = np.asarray(rl_msg.omega_d)
+        self.omega_d = np.asarray(rl_msg.M_d)
 
         ## TRIM RL VALUES FOR CSV
         self.alpha_mu = np.round(self.alpha_mu,2)


### PR DESCRIPTION
Updated controller to work off of moment based flip maneuvers instead of angular velocity based ones; which are difficult for the system to achieve due to acceleration/moment limits.  Achieving a desired moment is assumed to be very fast although not directly verified.

The resulting policy and performance was well within the bound of the system's capabilities and did not saturate the motors compared to the angular vel based flips. The policy equation was also normalized so that RREV_trigger, G1, & G2 are all in the range of (0 - 15.0) and will output a moment of (0 - 7.77) N*mm which is then converted into N*m inside the controller